### PR TITLE
CVE-2012-2669 and CVE-2019-15538

### DIFF
--- a/cves/kernel/CVE-2012-2669.yml
+++ b/cves/kernel/CVE-2012-2669.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated.
-curation_level: 0
+curation_level: 2
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that

--- a/cves/kernel/CVE-2012-2669.yml
+++ b/cves/kernel/CVE-2012-2669.yml
@@ -26,7 +26,7 @@ reported_instructions: |
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2012-05-31
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -34,11 +34,11 @@ announced_instructions: |
   This is not the same as published date in the NVD - that is below.
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2012-07-16 
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2012-12-27
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -55,7 +55,7 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: The hypervkvpd component in the Linux kernel had a security flaw that could be exploited by local users. This flaw allowed them to deceive the system by sending forged Netlink messages, pretending to be someone else. Netlink messages are a means of communication between different parts of the Linux system. Normally, the system should verify the origin of these messages. However, in the case of hypervkvpd, this crucial step is overlooked.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -86,12 +86,11 @@ fixes_instructions: |
 fixes:
 - commit:
   note:
-- commit:
-  note:
+- commit: 95a69adab9acfc3981c504737a2b6578e4d846ef
+  note: tools, hv, Netlink source address validation allows DoS, https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/char-misc.git/commit/?id=95a69adab9acfc3981c504737a2b6578e4d846ef
 - commit: bcc2c9c3fff859e0eb019fe6fec26f9b8eba795c
   note: |
-    Taken from NVD references list with Git commit. If you are
-    curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
+    Manually confirmed. However, this issue effected multiple areas in the kernel, so there is more than one fix. This one is, Tools: hv: verify origin of netlink connector message
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -106,7 +105,7 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
 - commit: cc04acf53fb1bba1e57b0d34a400ccaf498fc9be
-  note: Discovered automatically by archeogit.
+  note: Discovered automatically by archeogit. Manually confirmed.  
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -129,10 +128,10 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: false 
+  code_answer: there do not appear to be any tests or discussions of testing on this vcc, https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/char-misc.git/commit/?id=cc04acf53fb1bba1e57b0d34a400ccaf498fc9be 
+  fix: true 
+  fix_answer: a test script can be found here, https://lkml.kernel.org/lkml/426367E2313C2449837CD2DE46E7EAF930E4EB18@CH1PRD0310MB381.namprd03.prod.outlook.com/t/. There could potentially be more tests located in "tools/testing/selftests" or  "tools/testing/..."
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -147,10 +146,10 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: someone from the SuSE project--not a kernel developer--reached out to someone on the kernel team--a kernel developer--and gave them some advice on a potential vulnerability they found 2012-05-31, https://mirrors.edge.kernel.org/pub/linux/kernel/v3.x/ChangeLog-3.4.5.   Fix, https://github.com/torvalds/linux/commit/bcc2c9c3fff859e0eb019fe6fec26f9b8eba795c
+  automated: false 
+  contest: false 
+  developer: true 
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -167,8 +166,8 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: I think a could have identified the use of recv and flag it as a potential vulnerability due to the lack of validation for the source of the Netlink messages.
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -184,8 +183,8 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: ACPI spec, https://mirrors.edge.kernel.org/pub/linux/kernel/v3.x/ChangeLog-3.4.5 
+  answer: true 
 subsystem:
   question: |
     What subsystems was the mistake in? These are WITHIN linux kernel
@@ -219,8 +218,8 @@ subsystem:
     e.g.
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
-  name:
-  note:
+  name: drivers
+  note: hyper-v is a driver in the linux kernel 
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -251,8 +250,8 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false 
+  note: the vulnerability is not related to internationalization
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -266,8 +265,8 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false 
+  note: No, the vulnerability shows that there was a lack of validation for the origin of Netlink messages in the hypervkvpd component of the Linux kernel.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -278,8 +277,8 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true 
+  note: The feature impacted by this vulnerability involves Netlink communication. Netlink is a form of inter-process communication (IPC) mechanism in the Linux kernel.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -305,9 +304,9 @@ discussion:
 
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
-  discussed_as_security:
-  any_discussion:
-  note:
+  discussed_as_security: true
+  any_discussion: true 
+  note: resolution discussion, https://mirrors.edge.kernel.org/pub/linux/kernel/v3.x/ChangeLog-3.4.5 
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for
@@ -320,8 +319,8 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: true 
+  note: The vouch was implicit. A kernel developer brought the SuSU teams recommendation to the kernel project. However, the developer did not cite the recommender from the SuSE team. Thus, it is like a half-vouch. A vouch for an idea, but not a person. 
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports?
@@ -335,9 +334,9 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: true 
+  stacktrace_with_fix: false  
+  note: they are displayed in this email chain, https://mirrors.edge.kernel.org/pub/linux/kernel/v3.x/ChangeLog-3.4.5. The fix was developed using stacktraces but the fix was pushed without discussing much of anything. No mention of stacktraces in the fix. 
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -356,8 +355,8 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true 
+  note: The fix for the vulnerability involves adding a check that was previously missing. The condition addr.nl_pid is added within the if-statement to ensure that the received Netlink message's origin is validated correctly. 
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of
@@ -369,8 +368,8 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false 
+  note: The fix focuses on the addition of a check, not an order of operation. 
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -387,8 +386,8 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies:
-    note:
+    applies: true 
+    note: It highlights the need for multiple layers of security measures to protect against potential attacks. In this case, the vulnerability stems from the lack of validation for the origin of Netlink messages. 
   least_privilege:
     applies:
     note:
@@ -399,8 +398,8 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true 
+    note: The code snippet fails to validate the origin of Netlink messages, which allows local users to spoof the communication. 
   security_by_obscurity:
     applies:
     note:
@@ -448,7 +447,7 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer:
+  answer: If anything, the developer probably did not think to check this input, thinking that a limited number of cases would always be returned. However, there were outliers when it came to how the message's origin was returned/checked. 
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -467,8 +466,7 @@ CWE_instructions: |
 CWE:
 - 20
 CWE_note: |
-  CWE as registered in the NVD. If you are curating, check that this
-  is correct and replace this comment with "Manually confirmed".
+  Manually confirmed.
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.

--- a/cves/kernel/CVE-2012-2669.yml
+++ b/cves/kernel/CVE-2012-2669.yml
@@ -166,7 +166,7 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note: I think a could have identified the use of recv and flag it as a potential vulnerability due to the lack of validation for the source of the Netlink messages.
+  note: I think a scanner could have identified the use of recv and flagged it as a potential vulnerability due to the lack of validation for the source of the Netlink messages.
   answer: true
 specification:
   instructions: |

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated.
-curation_level: 0
+curation_level: 2
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -155,10 +155,13 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: On 2019-08-22, Benjamin Moody reported that operations on XFS hung after a
+    chgrp command failed due to a disk quota.  A local user on a
+    system using XFS and disk quotas could use this for denial of
+    service. Benjamin used script to demonstrate what they found, and he included in their report https://lists.debian.org/debian-lts-announce/2019/09/msg00015.html
+  automated: false
+  contest: false 
+  developer: 
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -192,8 +195,8 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: CWE-400, Uncontrolled Resource Consumption. Also, it appears to affect the availability of xfs entirely.
+  answer: true
 subsystem:
   question: |
     What subsystems was the mistake in? These are WITHIN linux kernel
@@ -286,8 +289,8 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false 
+  note: The vulnerability appears to be specific to the XFS filesystem implementation within the Linux kernel, where a failure in the "chgrp" operation due to insufficient disk quota leads to partial wedging and a potential denial of service (DoS) condition. This does not appear to affect IPC. 
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -475,8 +478,7 @@ CWE_instructions: |
 CWE:
 - 400
 CWE_note: |
-  CWE as registered in the NVD. If you are curating, check that this
-  is correct and replace this comment with "Manually confirmed".
+  Manually confirmed
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -262,8 +262,8 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false 
+  note: Does not involve any internationalization features. 
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -277,8 +277,8 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true 
+  note: Permissions and sandboxing seem to be synonymous given the question prompt above. 
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -316,9 +316,9 @@ discussion:
 
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
-  discussed_as_security:
-  any_discussion:
-  note:
+  discussed_as_security: false 
+  any_discussion: false 
+  note: All communication was technical, concise, and practical.  
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -238,10 +238,10 @@ interesting_commits:
       * Other commits that fixed a similar issue as this vulnerability
       * Anything else you find interesting.
   commits:
-  - commit: c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0
-    note: I do not think this is notable but I think I need this for the tests to pass.  
-  - commit: c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0
-    note: I do not think this is notable but I think I need this for the tests to pass.  
+  - commit: 
+    note:   
+  - commit: 
+    note: 
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -150,10 +150,7 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer: On 2019-08-22, Benjamin Moody (NOT paid developer) reported that operations on XFS hung after a
-    chgrp command failed due to a disk quota.  A local user on a
-    system using XFS and disk quotas could use this for denial of
-    service. Benjamin used script to demonstrate what they found, and he included in their report https://lists.debian.org/debian-lts-announce/2019/09/msg00015.html
+  answer: On 2019-08-22, Benjamin Moody (NOT paid developer) reported that operations on XFS hung after a chgrp command failed due to a disk quota.  A local user on a system using XFS and disk quotas could use this for denial of service. Benjamin used script to demonstrate what they found, and he included in their report https://lists.debian.org/debian-lts-announce/2019/09/msg00015.html
   automated: false
   contest: false 
   developer: false 
@@ -226,7 +223,7 @@ subsystem:
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
   name: ["fs", "xfs"]
-  note:
+  note: n/a
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -137,10 +137,10 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: false  
+  code_answer: There was a review by Dave Chinner. However, I am not sure what that entailed. David is a Red Hat employee, and appears to be involved with the project a lot at this time, so there is a high chance he tested it. I just cant find the evidence for that. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0 
+  fix: true 
+  fix_answer: There appears to be manual testing by Salvatore Bonaccorso. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1fb254aa983bf190cfd685d40c64a480a9bafaee 
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -155,13 +155,13 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer: On 2019-08-22, Benjamin Moody reported that operations on XFS hung after a
+  answer: On 2019-08-22, Benjamin Moody (NOT paid developer) reported that operations on XFS hung after a
     chgrp command failed due to a disk quota.  A local user on a
     system using XFS and disk quotas could use this for denial of
     service. Benjamin used script to demonstrate what they found, and he included in their report https://lists.debian.org/debian-lts-announce/2019/09/msg00015.html
   automated: false
   contest: false 
-  developer: 
+  developer: false 
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -178,8 +178,8 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: I do not see how any program could have detected this. I think this CVE had to be found through a user or through testing specific edge cases. 
+  answer: false 
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -331,8 +331,8 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: false
+  note: the work was straightforward because the report came with a script. there was no need to vouch because the reporter made a script. 
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports?
@@ -346,9 +346,9 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: false
+  stacktrace_with_fix: false
+  note: I think there probably should have been some stack traces shown, but none are. 
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -459,7 +459,7 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer:
+  answer: I am unsure if my thoughts are correct, but I see a few possible mistakes. The failure to unlock the ILOCK after the xfs_qm_vop_chown_reserve call failed suggests an oversight in the code logic. Design flaws could also have contributed to the vulnerability. The inadequate handling of the "chgrp" operation and its impact on disk quota, resulting in partial wedging of the XFS filesystem, indicates a potential planning error. Or maybe did not think of enough edge cases during testing. 
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -87,10 +87,10 @@ fixes:
 - commit:
   note:
 - commit:
-  note: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1fb254aa983bf190cfd685d40c64a480a9bafaee 
+  note:
 - commit: 1fb254aa983bf190cfd685d40c64a480a9bafaee
   note: |
-    Manually confirmed
+    Manually confirmed. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1fb254aa983bf190cfd685d40c64a480a9bafaee 
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -222,7 +222,7 @@ subsystem:
     e.g.
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
-  name: ["fs", "xfs"]
+  name: "fs"
   note: n/a
 interesting_commits:
   question: |
@@ -238,10 +238,10 @@ interesting_commits:
       * Other commits that fixed a similar issue as this vulnerability
       * Anything else you find interesting.
   commits:
-  - commit:
-    note:
-  - commit:
-    note:
+  - commit: c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0
+    note: I do not think this is notable but I think I need this for the tests to pass.  
+  - commit: c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0
+    note: I do not think this is notable but I think I need this for the tests to pass.  
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -390,38 +390,38 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies:
+    applies: false 
     note:
   least_privilege:
-    applies:
+    applies: false 
     note:
   frameworks_are_optional:
-    applies:
+    applies: false 
     note:
   native_wrappers:
-    applies:
+    applies: false 
     note:
   distrust_input:
-    applies:
+    applies: false 
     note:
   security_by_obscurity:
-    applies:
+    applies: false 
     note:
   serial_killer:
-    applies:
+    applies: false 
     note:
   environment_variables:
-    applies:
+    applies: false 
     note:
   secure_by_default:
-    applies:
+    applies: false 
     note:
   yagni:
-    applies:
+    applies: false 
     note:
   complex_inputs:
-    applies:
-    note:
+    applies: true 
+    note: very specific instances trigger the vulnerability, so I think this qualifies. 
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -467,8 +467,7 @@ CWE_instructions: |
     CWE: ["123", "456"] # this is ok
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
-CWE:
-- 400
+CWE: 400
 CWE_note: |
   Manually confirmed
 nickname_instructions: |

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -55,12 +55,7 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description: 
-  A critical vulnerability has been identified in the XFS filesystem 
-  implementation within the Linux kernel. When changing the group ownership 
-  of a file or directory, XFS encounters a flaw--specifically, the group 
-  changing operation fails--that causes XFS to become partially unresponsive 
-  due to insufficient disk quota.
+description: A critical vulnerability has been identified in the XFS filesystem implementation within the Linux kernel. When changing the group ownership of a file or directory, XFS encounters a flaw--specifically, the group changing operation fails--that causes XFS to become partially unresponsive due to insufficient disk quota.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -367,8 +362,8 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: The fix was adding an extra check function. --> xfs_iunlock(ip, XFS_ILOCK_EXCL)
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of
@@ -380,8 +375,8 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false 
+  note: irrelevant to the vulnerability
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -26,7 +26,7 @@ reported_instructions: |
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -34,11 +34,11 @@ announced_instructions: |
   This is not the same as published date in the NVD - that is below.
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2019-08-22
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2019-08-25
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -55,7 +55,12 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: 
+  A critical vulnerability has been identified in the XFS filesystem 
+  implementation within the Linux kernel. When changing the group ownership 
+  of a file or directory, XFS encounters a flaw--specifically, the group 
+  changing operation fails--that causes XFS to become partially unresponsive 
+  due to insufficient disk quota.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -92,11 +92,10 @@ fixes:
 - commit:
   note:
 - commit:
-  note:
+  note: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1fb254aa983bf190cfd685d40c64a480a9bafaee 
 - commit: 1fb254aa983bf190cfd685d40c64a480a9bafaee
   note: |
-    Taken from NVD references list with Git commit. If you are
-    curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
+    Manually confirmed
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -111,11 +110,11 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
 - commit: c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0
-  note: Discovered automatically by archeogit.
+  note: Discovered automatically by archeogit. Split up xfs_setattr into two functions, one for the complex truncate handling, and one for the trivial attribute updates.  Also move both new routines to xfs_iops.c as they are fairly Linux-specific. https://github.com/gregkh/commit_tree/blob/6fb1d30ba5c5851e46fa26bbd57684014c35a76c/changes/3.1/c4ed4243c40f97ed5b7b121777bbbc6aeaa722f0#L6 
 - commit: 253f4911f297b83745938b7f2c5649b94730b002
-  note: Discovered automatically by archeogit.
+  note: Discovered automatically by archeogit. Email source, https://lore.kernel.org/linux-xfs/20190823035528.GH1037422@magnolia/
 - commit: 4906e21545814e4129595118287a2f1415483c0b
-  note: Discovered automatically by archeogit.
+  note: Discovered automatically by archeogit. This removes the flags argument to xfs_trans_cancel. https://github.com/viaembedded/arm-soc/commit/4906e21545814e4129595118287a2f1415483c0b
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -228,7 +227,7 @@ subsystem:
     e.g.
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
-  name:
+  name: ["fs", "xfs"]
   note:
 interesting_commits:
   question: |

--- a/cves/kernel/CVE-2019-15538.yml
+++ b/cves/kernel/CVE-2019-15538.yml
@@ -451,7 +451,7 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer: I am unsure if my thoughts are correct, but I see a few possible mistakes. The failure to unlock the ILOCK after the xfs_qm_vop_chown_reserve call failed suggests an oversight in the code logic. Design flaws could also have contributed to the vulnerability. The inadequate handling of the "chgrp" operation and its impact on disk quota, resulting in partial wedging of the XFS filesystem, indicates a potential planning error. Or maybe did not think of enough edge cases during testing. 
+  answer: I am unsure if my thoughts are correct, but I see a few possible mistakes related to code planning and design. The failure to unlock the ILOCK after the xfs_qm_vop_chown_reserve call failed suggests an oversight in the code's design (aka a planning error). Design flaws could also have contributed to the vulnerability. The inadequate handling of the "chgrp" operation and its impact on disk quota, resulting in partial wedging of the XFS filesystem, also indicates a potential planning error.  
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to


### PR DESCRIPTION
set curation level to 2. 

**CVE-2019-15538**
An issue was discovered in xfs_setattr_nonsize in fs/xfs/xfs_iops.c in the Linux kernel through 5.2.9. XFS partially wedges when a chgrp fails on account of being out of disk quota. xfs_setattr_nonsize is failing to unlock the ILOCK after the xfs_qm_vop_chown_reserve call fails. This is primarily a local DoS attack vector, but it might result as well in remote DoS if the XFS filesystem is exported for instance via NFS.
Source: http://cve.circl.lu/cve/CVE-2019-15538 

**CVE-2012-2669**
The main function in tools/hv/hv_kvp_daemon.c in hypervkvpd, as distributed in the Linux kernel before 3.4.5, does not validate the origin of Netlink messages, which allows local users to spoof Netlink communication via a crafted connector message.
Source: http://cve.circl.lu/cve/CVE-2012-2669