### PR TITLE
CVE-2016-2545 and CVE-2022-28389

### DIFF
--- a/cves/kernel/CVE-2016-2545.yml
+++ b/cves/kernel/CVE-2016-2545.yml
@@ -58,7 +58,19 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |
+  The snd_timer_interrupt function, part of the Linux kernel's sound subsystem,
+  handles sound timer interrupts. A specific linked list within this function
+  is improperly managed. Local users can exploit this by crafting a special
+  ioctl call, leading to a use-after-free vulnerability. A use-after-free
+  vulnerability occurs when memory is accessed after it has been freed, which
+  can lead to a variety of issues, including program crashes and unpredictable
+  behavior.
+  
+  In this case, the exploitation leads to a race condition, a situation where
+  the system's behavior is dependent on the sequence or timing of other
+  uncontrollable events. This race condition can cause the system to crash,
+  resulting in a denial of service.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -434,8 +446,10 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: |
+      The snd_timer_interrupt function lacks control over its input, leading to
+      a use-after-free vulnerability.
   security_by_obscurity:
     applies:
     note:
@@ -446,8 +460,10 @@ lessons:
     applies:
     note:
   secure_by_default:
-    applies:
-    note:
+    applies: true
+    note: |
+      A safer function list_del_init was available but was not used correctly
+      leading to the vulnerability.
   yagni:
     applies:
     note:

--- a/cves/kernel/CVE-2016-2545.yml
+++ b/cves/kernel/CVE-2016-2545.yml
@@ -26,7 +26,9 @@ reported_instructions: |
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: '2016-01-12'
+# I believe this is the report
+# https://www.spinics.net/lists/alsa-devel/msg45082.html
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -38,7 +40,8 @@ announced_date: '2016-04-27'
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date: '2016-04-27'
+published_date: '2016-01-13'
+# Based on git commit.
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -75,7 +78,8 @@ bugs_instructions: |
     * Mentioned in mailing list discussions
     * References from NVD entry
     * Various other places
-bugs: [ ]
+bugs:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1311560
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -84,14 +88,8 @@ fixes_instructions: |
 
   Place any notes you would like to make in the notes field.
 fixes:
-  - commit:
-    note:
-  - commit:
-    note:
   - commit: ee8413b01045c74340aa13ad5bdf905de32be736
-    note: |
-      Taken from NVD references list with Git commit. If you are
-      curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
+    note: Manually Confirmed
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -106,7 +104,7 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
   - commit: 9244b2c3079faac79b3b961116bd548c45087e2c
-    note: Discovered automatically by archeogit.
+    note: Manually Confirmed
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -114,7 +112,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 0
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -129,10 +127,10 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: false
+  code_answer: No related unit tests could be found.
+  fix: false
+  fix_answer: No automated tests added.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -147,10 +145,13 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: |
+    This vulnerability was found by Dmitry Vyukov, a Google employee, by
+    utilizing Google's syzkaller fuzzer.
+    https://www.spinics.net/lists/alsa-devel/msg45082.html
+  automated: true
+  contest: false
+  developer: true
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -167,8 +168,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: |
+    The vulnerability was discovered using Google's syzkaller fuzzer. This
+    demonstrates that it's not only possible, but proven, that automated tools
+    can be used to uncover similar vulnerabilities.
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -184,8 +188,10 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: |
+    No related specification violations found in bug reports, kernel lore
+    discussions, commit messages, or mailing lists.
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in? These are WITHIN linux kernel
@@ -219,8 +225,10 @@ subsystem:
     e.g.
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
-  name:
-  note:
+  name: sound
+  note: |
+    The vulnerability is in the timers abstract layer of the Advanced Linux
+    Sound Architecture (ALSA).
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -235,8 +243,6 @@ interesting_commits:
       * Other commits that fixed a similar issue as this vulnerability
       * Anything else you find interesting.
   commits:
-    - commit:
-      note:
     - commit:
       note:
 i18n:
@@ -450,11 +456,10 @@ mistakes:
     industry would find interesting.
   answer:
 CWE_instructions: |
-  Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
+  Please go to https://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
   https://cwe.mitre.org/data/definitions/699.html for the Software Development
-  view of the vulnerabilities. We also recommend the tool
-  http://www.cwevis.org/viz to help see how the classifications work.
+  view of the vulnerabilities.
 
   If you have anything to note about why you classified it this way, write
   something in CWE_note. This field is optional.

--- a/cves/kernel/CVE-2016-2545.yml
+++ b/cves/kernel/CVE-2016-2545.yml
@@ -124,7 +124,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 0
+upvotes: 2
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -300,12 +300,13 @@ ipc:
     what your answer was.
   answer: false
   note: |
-    The snd_timer_interrupt function, where the vulnerability resides, does not
-    appear to utilize inter-process communication (IPC). It lacks typical IPC
-    mechanisms such as pipes, message queues, shared memory, or sockets.
-    However, it's plausible that the Advanced Linux Sound Architecture (ALSA)
-    system, which deals with sound timers, may use IPC in some capacity
-    elsewhere.
+    The snd_timer_interrupt function, a low-level timer interrupt, directly
+    interacts with hardware. Given its nature, it is highly unlikely
+    that it employs any form of userspace inter-process communication (IPC) such
+    as sockets, pipes, message queues, or shared memory. Therefore, any
+    potential IPC usage within the broader Advanced Linux Sound Architecture
+    (ALSA) system, which manages sound timers, would be unrelated to this
+    specific function.
 discussion:
   question: |
     Was there any discussion surrounding this?

--- a/cves/kernel/CVE-2016-2545.yml
+++ b/cves/kernel/CVE-2016-2545.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated.
-curation_level: 0
+curation_level: 2
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that
@@ -64,7 +64,7 @@ bounty:
   amt:
   announced:
   url:
-reviews: []
+reviews: [ ]
 bugs_instructions: |
   What bugs are involved in this vulnerability?
 
@@ -75,7 +75,7 @@ bugs_instructions: |
     * Mentioned in mailing list discussions
     * References from NVD entry
     * Various other places
-bugs: []
+bugs: [ ]
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -84,14 +84,14 @@ fixes_instructions: |
 
   Place any notes you would like to make in the notes field.
 fixes:
-- commit:
-  note:
-- commit:
-  note:
-- commit: ee8413b01045c74340aa13ad5bdf905de32be736
-  note: |
-    Taken from NVD references list with Git commit. If you are
-    curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
+  - commit:
+    note:
+  - commit:
+    note:
+  - commit: ee8413b01045c74340aa13ad5bdf905de32be736
+    note: |
+      Taken from NVD references list with Git commit. If you are
+      curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -105,8 +105,8 @@ vcc_instructions: |
 
   Place any notes you would like to make in the notes field.
 vccs:
-- commit: 9244b2c3079faac79b3b961116bd548c45087e2c
-  note: Discovered automatically by archeogit.
+  - commit: 9244b2c3079faac79b3b961116bd548c45087e2c
+    note: Discovered automatically by archeogit.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -235,10 +235,10 @@ interesting_commits:
       * Other commits that fixed a similar issue as this vulnerability
       * Anything else you find interesting.
   commits:
-  - commit:
-    note:
-  - commit:
-    note:
+    - commit:
+      note:
+    - commit:
+      note:
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -465,7 +465,7 @@ CWE_instructions: |
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
 CWE:
-- 362
+  - 362
 CWE_note: |
   CWE as registered in the NVD. If you are curating, check that this
   is correct and replace this comment with "Manually confirmed".

--- a/cves/kernel/CVE-2016-2545.yml
+++ b/cves/kernel/CVE-2016-2545.yml
@@ -257,8 +257,8 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: This relates to a linked list.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -272,8 +272,10 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |
+    The vulnerability is a race condition in the snd_timer_interrupt function,
+    which is not related to sandboxing features.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -284,8 +286,14 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |
+    The snd_timer_interrupt function, where the vulnerability resides, does not
+    appear to utilize inter-process communication (IPC). It lacks typical IPC
+    mechanisms such as pipes, message queues, shared memory, or sockets.
+    However, it's plausible that the Advanced Linux Sound Architecture (ALSA)
+    system, which deals with sound timers, may use IPC in some capacity
+    elsewhere.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -311,9 +319,14 @@ discussion:
 
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
-  discussed_as_security:
-  any_discussion:
-  note:
+  discussed_as_security: false
+  any_discussion: true
+  note: |
+    While I don't believe this was explicitly discussed as a security issue,
+    it was discovered and discussed as a use-after-free memory vulnerability, 
+    which does have security implications.
+    https://www.spinics.net/lists/alsa-devel/msg45082.html
+    https://lore.kernel.org/lkml/lsq.1454975631.69933183@decadent.org.uk/
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for
@@ -326,8 +339,17 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: true
+  note: |
+    The patch commit itself was overseen by numerous employees from reputable
+    organizations. The vulnerability was discovered by Dmitry Vyukov, an
+    employee at Google, using the syzkaller fuzzer. The patch was subsequently
+    developed by Takashi Iwai from SUSE. Dmitry Vyukov then tested this patch.
+    The final sign-off on the patch was done by Ben Hutchings, a Debian
+    Developer.
+    
+    Further examination of various discussions would likely reveal that this fix
+    was reviewed by an even larger number of individuals.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports?
@@ -341,9 +363,12 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: true
+  stacktrace_with_fix: true
+  note: |
+    The stacktrace in the bug report points to the file `sound/core/timer.c`
+    where the vulnerability resides and where the fix was applied.
+    https://www.spinics.net/lists/alsa-devel/msg45082.html
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -362,8 +387,10 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |
+    The fix was to use a slightly different function variant for deleting
+    entries from the linked list. The fix did not include adding any checks.
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of
@@ -375,8 +402,10 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |
+    The fix does not involve moving code around or changing the order of how
+    things are done.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -454,7 +483,17 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer:
+  answer: |
+    The vulnerability in this case was caused by a lapse. The developers were
+    already using the safer function list_del_init in other parts of the code,
+    but they overlooked its use in this specific instance,leading to the
+    vulnerability.
+    
+    The commit 9244b2c, referenced above, introduced a change in the list
+    handling from list_for_each to list_for_each_entry across the
+    Advanced Linux Sound Architecture (ALSA). However, the developers failed to
+    recognize that the list_del function needed to be replaced with
+    list_del_init to prevent this vulnerability.
 CWE_instructions: |
   Please go to https://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -471,12 +510,10 @@ CWE_instructions: |
     CWE: 123            # also ok
 CWE:
   - 362
-CWE_note: |
-  CWE as registered in the NVD. If you are curating, check that this
-  is correct and replace this comment with "Manually confirmed".
+CWE_note: Manually Confirmed
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.
   Must be under 30 characters. Optional.
 nickname:
-CVSS:
+CVSS: CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated.
-curation_level: 0
+curation_level: 2
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that
@@ -64,7 +64,7 @@ bounty:
   amt:
   announced:
   url:
-reviews: []
+reviews: [ ]
 bugs_instructions: |
   What bugs are involved in this vulnerability?
 
@@ -75,7 +75,7 @@ bugs_instructions: |
     * Mentioned in mailing list discussions
     * References from NVD entry
     * Various other places
-bugs: []
+bugs: [ ]
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -84,14 +84,14 @@ fixes_instructions: |
 
   Place any notes you would like to make in the notes field.
 fixes:
-- commit:
-  note:
-- commit:
-  note:
-- commit: 04c9b00ba83594a29813d6b1fb8fdc93a3915174
-  note: |
-    Taken from NVD references list with Git commit. If you are
-    curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
+  - commit:
+    note:
+  - commit:
+    note:
+  - commit: 04c9b00ba83594a29813d6b1fb8fdc93a3915174
+    note: |
+      Taken from NVD references list with Git commit. If you are
+      curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -105,8 +105,8 @@ vcc_instructions: |
 
   Place any notes you would like to make in the notes field.
 vccs:
-- commit: 51f3baad7de943780ce0c17bd7975df567dd6e14
-  note: Discovered automatically by archeogit.
+  - commit: 51f3baad7de943780ce0c17bd7975df567dd6e14
+    note: Discovered automatically by archeogit.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -235,10 +235,10 @@ interesting_commits:
       * Other commits that fixed a similar issue as this vulnerability
       * Anything else you find interesting.
   commits:
-  - commit:
-    note:
-  - commit:
-    note:
+    - commit:
+      note:
+    - commit:
+      note:
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -465,7 +465,7 @@ CWE_instructions: |
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
 CWE:
-- 415
+  - 415
 CWE_note: |
   CWE as registered in the NVD. If you are curating, check that this
   is correct and replace this comment with "Manually confirmed".

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -92,7 +92,7 @@ bugs_instructions: |
     * Mentioned in mailing list discussions
     * References from NVD entry
     * Various other places
-bugs: [ ]
+bugs: [ "https://bugzilla.redhat.com/show_bug.cgi?id=2073086", "https://bugzilla.redhat.com/show_bug.cgi?id=2073087" ]
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -106,9 +106,7 @@ fixes:
   - commit:
     note:
   - commit: 04c9b00ba83594a29813d6b1fb8fdc93a3915174
-    note: |
-      Taken from NVD references list with Git commit. If you are
-      curating, please fact-check that this commit fixes the vulnerability and replace this comment with 'Manually confirmed'
+    note: Manually Confirmed
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -123,7 +121,7 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
   - commit: 51f3baad7de943780ce0c17bd7975df567dd6e14
-    note: Discovered automatically by archeogit.
+    note: Manually Confirmed
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -131,7 +129,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 6
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -146,9 +144,9 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
-  code_answer:
-  fix:
+  code: true
+  code_answer: No unit tests.
+  fix: false
   fix_answer:
 discovered:
   question: |
@@ -342,7 +340,8 @@ vouch:
       * upvoting a solution on a pull request
 
     Answer must be true or false.
-    Write a note about how you came to the conclusions you did, regardless of what your answer was.
+    Write a note about how you came to the conclusions you did, regardless of
+    what your answer was.
   answer: true
   note: |
     From 
@@ -493,9 +492,7 @@ CWE_instructions: |
     CWE: 123            # also ok
 CWE:
   - 415
-CWE_note: |
-  CWE as registered in the NVD. If you are curating, check that this
-  is correct and replace this comment with "Manually confirmed".
+CWE_note: Manually Confirmed
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -40,7 +40,7 @@ published_instructions: |
   Please enter your date in YYYY-MM-DD format.
 published_date: '2022-04-03'
 description_instructions: |
-  You can get an initial description from the CVE entry on cve.mitre.org. These
+  You can get an initial description from the CVE entry on cve.org. These
   descriptions are a fine start, but they can be kind of jargony.
 
   Rewrite this description IN YOUR OWN WORDS. Make it interesting and easy to
@@ -55,7 +55,24 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |
+  When a program runs, it needs to keep track of which memory it is using and
+  which memory is free. This information is stored in a data structure called
+  the memory management unit (MMU). The MMU is typically located on the CPU chip
+  itself, but it can also be stored in a separate chip or even in main memory.
+
+  The Linux kernel function mcba_usb_start_xmit() accidentally freed the same
+  memory twice. This is called a double free. When a double free occurs, the
+  MMU becomes confused. When a program tries to allocate memory again, the MMU
+  may give it the same memory block that was already freed. This is called a
+  double allocation.
+
+  Double allocations can cause a number of problems. For example, two programs
+  may be given the same memory block and overwrite each other's data. Or, a
+  program may try to access memory that has been freed, which can cause the
+  program to crash. This matters because an attacker could exploit this
+  vulnerability to cause a denial-of-service (DoS) attack or even execute
+  arbitrary code.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -147,7 +164,10 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer:
+  answer: |
+    This issue was discovered while Hangyu Hua was discussing an incorrect patch
+      with Marc Kleine-Budde.
+      https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
   automated:
   contest:
   developer:
@@ -306,8 +326,11 @@ discussion:
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
   discussed_as_security:
-  any_discussion:
-  note:
+  any_discussion: true
+  note: |
+    https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
+
+    https://lore.kernel.org/all/20220311080208.45047-1-hbh25y@gmail.com/
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for
@@ -320,8 +343,12 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: true
+  note: |
+    From 
+    https://lore.kernel.org/all/20220228075146.hvui3iow7niupij4@pengutronix.de/
+    Marc Kleine-Budde helped Hangyu Hua find the issue. In the commit message
+    both Hangyu Hua and Marc Kleine-Budde signed off on the fix.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports?

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -27,6 +27,7 @@ reported_instructions: |
 
   Please enter your date in YYYY-MM-DD format.
 reported_date:
+# TODO: Should I set to the date found?
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -92,19 +93,18 @@ bugs_instructions: |
     * Mentioned in mailing list discussions
     * References from NVD entry
     * Various other places
-bugs: [ "https://bugzilla.redhat.com/show_bug.cgi?id=2073086", "https://bugzilla.redhat.com/show_bug.cgi?id=2073087" ]
+bugs:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=2073086
+  - https://bugzilla.redhat.com/show_bug.cgi?id=2073087
+  # TODO: Correct syntax?
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
   This must be a git commit hash from the systemd source repo, a  40-character
-  hexademical string/
+  hexadecimal string/
 
   Place any notes you would like to make in the notes field.
 fixes:
-  - commit:
-    note:
-  - commit:
-    note:
   - commit: 04c9b00ba83594a29813d6b1fb8fdc93a3915174
     note: Manually Confirmed
 vcc_instructions: |
@@ -129,7 +129,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 6
+upvotes: 0
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -146,8 +146,9 @@ unit_tested:
     adding or improving an automated test to ensure this doesn't happen again.
   code: true
   code_answer: No unit tests.
+  # TODO: I'm unsure.
   fix: false
-  fix_answer:
+  fix_answer: No automated tests added.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -166,9 +167,10 @@ discovered:
     This issue was discovered while Hangyu Hua was discussing an incorrect patch
       with Marc Kleine-Budde.
       https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
-  automated:
-  contest:
-  developer:
+  automated: false
+  contest: false
+  developer: null
+  # TODO: Is this null?
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -187,6 +189,7 @@ autodiscoverable:
     why you come to that conclusion.
   note:
   answer:
+  # TODO: I'm unsure.
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -202,8 +205,10 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: |
+    I did not find any related specification violations in the redhat bug
+    reports, kernel lore discussions, commit messages, or mailing lists.
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in? These are WITHIN linux kernel
@@ -239,6 +244,7 @@ subsystem:
         name: subsystemA # also ok
   name:
   note:
+  # TODO: I am assuming drivers, network, and usb? (CAN bus)
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -269,8 +275,8 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: This relates to memory allocation.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -284,7 +290,7 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
+  answer: false
   note:
 ipc:
   question: |
@@ -296,8 +302,9 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: The mcba_usb driver uses IPC to communicate with the Linux kernel.
+  # TODO: Review this.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -327,7 +334,6 @@ discussion:
   any_discussion: true
   note: |
     https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
-
     https://lore.kernel.org/all/20220311080208.45047-1-hbh25y@gmail.com/
 vouch:
   question: |
@@ -361,9 +367,10 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: false
+  stacktrace_with_fix: false
+  note: I did not notice any stacktraces in any bug reports or discussions.
+  # TODO: Is this sufficient?
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -382,8 +389,10 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |
+    The fix removed a redundant function call that led to memory being freed
+    twice. There were no additions to the fix.
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of
@@ -395,8 +404,12 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: |
+    There was discussion about the order of calling certain functions. The final
+    fix removed a single function call, but it does relate to the ordering of
+    how and when memory is freed.
+  # TODO: I'm unsure if this is correct?
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -26,8 +26,7 @@ reported_instructions: |
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
-# TODO: Should I set to the date found?
+reported_date: '2022-02-28'
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -61,19 +60,24 @@ description: |
   which memory is free. This information is stored in a data structure called
   the memory management unit (MMU). The MMU is typically located on the CPU chip
   itself, but it can also be stored in a separate chip or even in main memory.
-
-  The Linux kernel function mcba_usb_start_xmit() accidentally freed the same
+  
+  The mca_usb driver is used to connect the Microchip CAN BUS Analyzer Tool
+  to a computer using a USB cable. The SocketCAN framework is used to provide
+  a CAN bus interface to the Linux kernel.
+  
+  The function mcba_usb_start_xmit() accidentally freed the same
   memory twice. This is called a double free. When a double free occurs, the
   MMU becomes confused. When a program tries to allocate memory again, the MMU
   may give it the same memory block that was already freed. This is called a
   double allocation.
-
+  
   Double allocations can cause a number of problems. For example, two programs
   may be given the same memory block and overwrite each other's data. Or, a
   program may try to access memory that has been freed, which can cause the
   program to crash. This matters because an attacker could exploit this
   vulnerability to cause a denial-of-service (DoS) attack or even execute
-  arbitrary code.
+  arbitrary code. Such as sending a specially crafted CAN frame to the mca_usb
+  device.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -96,7 +100,6 @@ bugs_instructions: |
 bugs:
   - https://bugzilla.redhat.com/show_bug.cgi?id=2073086
   - https://bugzilla.redhat.com/show_bug.cgi?id=2073087
-  # TODO: Correct syntax?
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -144,9 +147,8 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code: true
-  code_answer: No unit tests.
-  # TODO: I'm unsure.
+  code: false
+  code_answer: No related unit tests could be found.
   fix: false
   fix_answer: No automated tests added.
 discovered:
@@ -157,7 +159,7 @@ discovered:
     originally found. Answer in longform below in "answer", fill in the date in
     YYYY-MM-DD, and then determine if the vulnerability was found by a Google
     employee (you can tell from their email address). If it's clear that the
-    vulenrability was discovered by a contest, fill in the name there.
+    vulnerability was discovered by a contest, fill in the name there.
 
     The automated, contest, and developer flags can be true, false, or nil.
 
@@ -170,7 +172,7 @@ discovered:
   automated: false
   contest: false
   developer: null
-  # TODO: Is this null?
+  # I am unsure. Marc Kleine-Budde is from Pengutronix. Null?
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -187,9 +189,12 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
-  # TODO: I'm unsure.
+  note: |
+    It is plausible that a fully automated tool could have discovered this
+    vulnerability. A double free can be detected using memory debugging tools
+    like Valgrind, static analysis tools, and even some fuzzers may be used to
+    generate random inputs that may trigger the vulnerability.
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -206,8 +211,8 @@ specification:
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
   note: |
-    I did not find any related specification violations in the redhat bug
-    reports, kernel lore discussions, commit messages, or mailing lists.
+    No related specification violations found in bug reports, kernel lore
+    discussions, commit messages, or mailing lists.
   answer: false
 subsystem:
   question: |
@@ -242,9 +247,10 @@ subsystem:
     e.g.
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
-  name:
-  note:
-  # TODO: I am assuming drivers, network, and usb? (CAN bus)
+  name: [ "drivers", "usb", "net" ]
+  note: |
+    The mca_usb driver is a SocketCAN driver, which handles both USB and
+    networking.
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -259,10 +265,10 @@ interesting_commits:
       * Other commits that fixed a similar issue as this vulnerability
       * Anything else you find interesting.
   commits:
-    - commit:
-      note:
-    - commit:
-      note:
+    - commit: 91c02557174be7f72e46ed7311e3bea1939840b0
+      note: |
+        A memory leak in the same mcba_usb driver was found a year prior to
+        this vulnerability. It was reported by Syzbot.
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -291,7 +297,10 @@ sandbox:
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
   answer: false
-  note:
+  note: |
+    This vulnerability relates to a network driver that communicates with using
+    the USB subsystem. It does not affect the permissions of other users or
+    processes. It does not relate to any sandboxing features.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -304,7 +313,6 @@ ipc:
     what your answer was.
   answer: true
   note: The mcba_usb driver uses IPC to communicate with the Linux kernel.
-  # TODO: Review this.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -330,10 +338,15 @@ discussion:
 
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
-  discussed_as_security:
+  discussed_as_security: false
   any_discussion: true
   note: |
+    This was found while discussing a separate patch for a memory leak in 
+    esd_usb2_start_xmit.
     https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
+    
+    There was discussion regarding this vulnerability such as how to resolve the
+    possible double free.
     https://lore.kernel.org/all/20220311080208.45047-1-hbh25y@gmail.com/
 vouch:
   question: |
@@ -350,10 +363,11 @@ vouch:
     what your answer was.
   answer: true
   note: |
-    From 
+    Marc Kleine-Budde helped Hangyu Hua find the issue in a lore discussion,
     https://lore.kernel.org/all/20220228075146.hvui3iow7niupij4@pengutronix.de/
-    Marc Kleine-Budde helped Hangyu Hua find the issue. In the commit message
-    both Hangyu Hua and Marc Kleine-Budde signed off on the fix.
+    
+    In the commit message both Hangyu Hua and Marc Kleine-Budde signed off on
+    the fix.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports?
@@ -369,8 +383,7 @@ stacktrace:
     what your answer was.
   any_stacktraces: false
   stacktrace_with_fix: false
-  note: I did not notice any stacktraces in any bug reports or discussions.
-  # TODO: Is this sufficient?
+  note: No stacktraces were noticed in any bug reports or discussions.
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -392,7 +405,7 @@ forgotten_check:
   answer: false
   note: |
     The fix removed a redundant function call that led to memory being freed
-    twice. There were no additions to the fix.
+    twice. The fix did not include adding any checks.
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of
@@ -409,7 +422,6 @@ order_of_operations:
     There was discussion about the order of calling certain functions. The final
     fix removed a single function call, but it does relate to the ordering of
     how and when memory is freed.
-  # TODO: I'm unsure if this is correct?
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -487,13 +499,19 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer:
+  answer: |
+    This vulnerability seems to be caused by a coding mistake, specifically a
+    logic error. The call to dev_kfree_skb() in mcba_usb_start_xmit() led to a
+    double free. This was likely a slip where they did not realize memory was
+    already being freed.
+    
+    More robust testing practices and more stringent code reviews could have
+    caught this mistake before deployment.
 CWE_instructions: |
-  Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
+  Please go to https://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
   https://cwe.mitre.org/data/definitions/699.html for the Software Development
-  view of the vulnerabilities. We also recommend the tool
-  http://www.cwevis.org/viz to help see how the classifications work.
+  view of the vulnerabilities.
 
   If you have anything to note about why you classified it this way, write
   something in CWE_note. This field is optional.
@@ -510,5 +528,6 @@ nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.
   Must be under 30 characters. Optional.
-nickname:
+nickname: McDoubleFree
+# I have no clue. mcba + double free = McDoubleFree
 CVSS: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -38,7 +38,8 @@ announced_date: '2022-04-03'
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date: '2022-04-03'
+published_date: '2022-03-31'
+# Based on git commit.
 description_instructions: |
   You can get an initial description from the CVE entry on cve.org. These
   descriptions are a fine start, but they can be kind of jargony.

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -57,28 +57,22 @@ description_instructions: |
   Your target audience is people just like you before you took any course in
   security
 description: |
-  When a program runs, it needs to keep track of which memory it is using and
-  which memory is free. This information is stored in a data structure called
-  the memory management unit (MMU). The MMU is typically located on the CPU chip
-  itself, but it can also be stored in a separate chip or even in main memory.
-  
-  The mca_usb driver is used to connect the Microchip CAN BUS Analyzer Tool
-  to a computer using a USB cable. The SocketCAN framework is used to provide
-  a CAN bus interface to the Linux kernel.
-  
-  The function mcba_usb_start_xmit() accidentally freed the same
-  memory twice. This is called a double free. When a double free occurs, the
-  MMU becomes confused. When a program tries to allocate memory again, the MMU
-  may give it the same memory block that was already freed. This is called a
-  double allocation.
-  
-  Double allocations can cause a number of problems. For example, two programs
-  may be given the same memory block and overwrite each other's data. Or, a
-  program may try to access memory that has been freed, which can cause the
-  program to crash. This matters because an attacker could exploit this
-  vulnerability to cause a denial-of-service (DoS) attack or even execute
-  arbitrary code. Such as sending a specially crafted CAN frame to the mca_usb
-  device.
+  The mca_usb driver, a component of the Linux kernel, interfaces with the 
+  Microchip CAN BUS Analyzer Tool via USB, utilizing the SocketCAN framework. 
+  A double free error was identified in the mcba_usb_start_xmit() function, 
+  where the same memory block was erroneously freed twice. This mishap can 
+  lead to a double allocation scenario.
+
+  Double allocation occurs when a program, unaware of a previous deallocation, 
+  allocates the same memory block again. This can result in multiple programs 
+  being assigned the same memory block, leading to data overwrites. It can 
+  also cause a program to access memory that has already been freed, leading 
+  to crashes.
+
+  The significance of this vulnerability lies in its potential exploitation 
+  by an attacker to induce a denial-of-service (DoS) attack or execute 
+  arbitrary code. For instance, an attacker could send a specially crafted 
+  CAN frame to the mca_usb device, exploiting this vulnerability.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -133,7 +127,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 0
+upvotes: 1
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -312,8 +306,10 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer: true
-  note: The mcba_usb driver uses IPC to communicate with the Linux kernel.
+  answer: false
+  note: |
+    The mcba_usb driver primarily interacts with the Linux kernel through its
+    netdev_ops structure, not through inter-process communication (IPC).
 discussion:
   question: |
     Was there any discussion surrounding this?

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -172,8 +172,8 @@ discovered:
     https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
   automated: false
   contest: false
-  developer: null
-  # I am unsure. Marc Kleine-Budde is from Pengutronix. Null?
+  developer: false
+  # I am unsure. Marc Kleine-Budde was from Pengutronix.
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered

--- a/cves/kernel/CVE-2022-28389.yml
+++ b/cves/kernel/CVE-2022-28389.yml
@@ -168,8 +168,8 @@ discovered:
     explain where you looked.
   answer: |
     This issue was discovered while Hangyu Hua was discussing an incorrect patch
-      with Marc Kleine-Budde.
-      https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
+    with Marc Kleine-Budde.
+    https://lore.kernel.org/all/20220225060019.21220-1-hbh25y@gmail.com/
   automated: false
   contest: false
   developer: null


### PR DESCRIPTION
Updated CVE-2016-2545 and CVE-2022-28389. CVE-2016-2545 is an issue with improper management of a linked list in the snd_timer_interrupt function, part of the Linux kernel's sound subsystem. CVE-2022-28389 is a double free vulnerability in the mca_usb driver, which is used to connect the Microchip CAN BUS Analyzer Tool. 

The updates include detailed information about the vulnerabilities, their discovery, fixes, and related discussions. The changes also validate the classification of the vulnerabilities according to CWE and CVSS scores.